### PR TITLE
#5: Added npm instructions to the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ development and deployment easier. They include:
 
 ## Development
 
-1. `cd` into this directory and run `gulp serve` to start the Express server.
-   This should open `http://localhost:3000` in a browser window.
+1. Install Node.js/npm if you don't already have them.
+1. `cd` into this directory and run `npm install` to install the dependencies.
+1. Run `gulp serve` to start the Express server. This should open
+   `http://localhost:3000` in a browser window.
 1. In a separate terminal, `cd` into this directory and run `gulp watch`.
 1. Edit files in the src/ directory. As you do so, `gulp watch` will compile the
    src/ files into the dist/ directory. As the dist/ files are updated, the page


### PR DESCRIPTION
For background:

npm is a very widely used tool to pull in dependencies (other people's code). The package.json file - which gets modified by running commands like `npm install gulp --save-dev` when you need to add a dependency - lists the packages used on this project. package-lock.json is then auto-generated from that in order to keep track of the specific versions of all of the dependencies used on this project (our dependencies will have other dependencies and so on - it can get pretty wild and messy behind the curtain). By having the lock file, we can ensure that we're both running the same exact code and that new versions of our dependencies are only updated when we are able to test them and make sure the changes didn't break anything.

Running `npm install` downloads that code into the node_modules directory within the repository. It's common practice to not commit that code to your repository because it's already stored elsewhere, it'd be a ton of code, and it would make managing PRs more difficult. That's why the directory is listed in the .gitignore file at the root of the repository and why we have to run `npm install` after cloning the repo. (It's also common practice to not store the "built" files - the dist/ directory in our case. Instead, `npm install` and `gulp build` are run by Netlify during deployment, which replicates what's happening locally as we change files.)

If that makes enough sense and my changes to the README seem right, go ahead and approve. Thanks!