### PR TITLE
#60: Added Google map instead of band pic. Updated event info.

### DIFF
--- a/src/html/homepage.html
+++ b/src/html/homepage.html
@@ -86,13 +86,13 @@
         <img class="events__list-icon" src="/assets/icons/icon-microphone.svg" alt="Microphone">
         <div class="events__list-info">
           <div class="events__list-time">
-            <h4 class="text text--subtitle-1 text--turquise">First friday each month, 8:00 P.M. - 11:00 P.M.</h4>
+            <h4 class="text text--subtitle-1 text--turquise">TBA</h4>
           </div>
           <div class="events__list-title">
             <h3 class="text text--title-4 text--white">Party! Party! at Smash Park</h3>
           </div>
           <div class="events__list-body">
-            <p class="text text--body-2 text--white">Catch us in the upstairs bar at Smash Park on the first Friday of each month. No cover charge and a free jello shot with every song you sing!</p>
+            <p class="text text--body-2 text--white">Catch us in the upstairs bar at Smash Park! No cover charge and a free jello shot with every song you sing! Check back here for upcoming dates!</p>
           </div>
         </div>
       </li>

--- a/src/html/schedule.html
+++ b/src/html/schedule.html
@@ -28,7 +28,9 @@
     <h2 class="text text--title-1">Upcoming Events</h2>
   </div>
   <div class="schedule__featured-event">
-    <img src="/assets/images/band-pic-2.jpg" alt="The guys in the band having a pizza party" class="schedule__featured-event-image">
+    <!-- I just copied this straight out of google, do you think I should get rid of more of those inline styles besides height and width? -->
+    <iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d11937.024897858579!2d-93.6372449!3d41.5853394!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x7f9f9bdf9a8c95e6!2sGas%20Lamp!5e0!3m2!1sen!2sus!4v1610026928408!5m2!1sen!2sus" frameborder="0" allowfullscreen="" class="schedule__featured-event-image"></iframe>
+    <!-- <img src="/assets/images/band-pic-2.jpg" alt="The guys in the band having a pizza party" class="schedule__featured-event-image"> -->
     <div class="schedule__featured-event-info">
       <div class="schedule__featured-event-date">
         <p class="text text--subtitle-1 text--turquise">Every sunday @ 8:00 pm - 12:00 am</p>
@@ -48,12 +50,12 @@
   <ul class="schedule__event-list">
     <li class="schedule__event-item">
       <div class="schedule__event-short-date">
-        <p class="text text--title-6 text--blue-grey">Nov<br>22</p>
+        <p class="text text--title-6 text--blue-grey">Jan<br>7</p>
       </div>
       <div class="schedule__event-info">
         <div class="schedule__event-date">
           <p class="text text--subtitle-1 text--turquise">
-            Sun Nov 22, 8:00 PM - 12:00 AM
+            Sun Jan 7, 8:00 PM - 12:00 AM
           </p>
         </div>
         <div class="schedule__event-title">
@@ -66,12 +68,12 @@
     </li>
     <li class="schedule__event-item">
       <div class="schedule__event-short-date">
-        <p class="text text--title-6 text--blue-grey">Nov<br>29</p>
+        <p class="text text--title-6 text--blue-grey">Jan<br>14</p>
       </div>
       <div class="schedule__event-info">
         <div class="schedule__event-date">
           <p class="text text--subtitle-1 text--turquise">
-            Sun Nov 29, 8:00 PM - 12:00 AM
+            Sun Jan 14, 8:00 PM - 12:00 AM
           </p>
         </div>
         <div class="schedule__event-title">
@@ -84,16 +86,16 @@
     </li>
     <li class="schedule__event-item">
       <div class="schedule__event-short-date">
-        <p class="text text--title-6 text--blue-grey">Dec<br>4</p>
+        <p class="text text--title-6 text--blue-grey">Jan<br>21</p>
       </div>
       <div class="schedule__event-info">
         <div class="schedule__event-date">
           <p class="text text--subtitle-1 text--turquise">
-            Fri Nov 14, 8:00 PM - 11:00 PM
+            Sun Jan 21, 8:00 PM - 12:00 AM
           </p>
         </div>
         <div class="schedule__event-title">
-          <h3 class="text text--title-4 text--white">Party! Party! at Smash Park</h3>
+          <h3 class="text text--title-4 text--white">Party! Party! at Gas Lamp</h3>
         </div>
         <div class="schedule__event-location">
           <p class="text text--body-1">Des Moines, IA</p>

--- a/src/scss/components/_schedule.scss
+++ b/src/scss/components/_schedule.scss
@@ -46,7 +46,7 @@
 
 .schedule__featured-event-image {
   justify-self: center;
-  height: auto;
+  height: 250px;
   margin-bottom: rhythm(3);
   width: 100%;
 


### PR DESCRIPTION
I thought a google map looked better on the featured event portion of events page than another derpy picture of the band. I deleted most of the extra html pieces that are automatically added with embedding a google map image. Can you take a look at let me know if it looks okay to you? I'll delete that commented out image before merging. Thank you!